### PR TITLE
Enable a user to be fetched after upadating profiles

### DIFF
--- a/src/store/actions/profiles/profileActions.js
+++ b/src/store/actions/profiles/profileActions.js
@@ -15,5 +15,6 @@ export const updateProfile = (profile, username) => (dispatch, getState, http) =
     .put(`profile/${username}`, { bio: profile.bio, image: profile.image })
     .then(data => {
       dispatch({ type: types.UPDATE_PROFILE, payload: data });
+      dispatch({ type: types.FETCH_PROFILE, payload: data });
       window.Notify.success('Profile updated');
     });

--- a/src/store/actions/profiles/profileActions.test.js
+++ b/src/store/actions/profiles/profileActions.test.js
@@ -26,7 +26,10 @@ describe('async actions', () => {
       status: 201,
       body: { data },
     });
-    const expectedActions = [{ type: types.UPDATE_PROFILE, payload: { data } }];
+    const expectedActions = [
+      { type: types.UPDATE_PROFILE, payload: { data } },
+      { type: types.FETCH_PROFILE, payload: { data } },
+    ];
     return store.dispatch(updateProfile(data, username)).then(() => {
       expect(store.getActions()).toEqual(expectedActions);
     });


### PR DESCRIPTION
#### What this PR does?
Allow user's profile to be fetched after an updating profile hence no need to refresh 
#### screenshots
<img width="747" alt="screen shot 2018-12-21 at 12 05 13" src="https://user-images.githubusercontent.com/39129473/50334554-bc1f4d00-0519-11e9-9309-af8d1e66cdd7.png">
